### PR TITLE
Remove NodeJS tools step which causes pipeline build error.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
     agent any
-    tools {
-        nodejs 'NodeJS-V8.x'
-    }
     stages {
         stage('build mem-geo-service'){
             steps {


### PR DESCRIPTION
NodeJS step is apparently unnecessary and causes the pipeline build to immediately fail.
Tested this version in OpenShift and it builds successfully.